### PR TITLE
`serializar_paquete` *devuelve* el tamaño del buffer

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -8,7 +8,7 @@
 #include "utils.h"
 
 //TODO
-void* serializar_paquete(t_paquete* paquete, int bytes)
+void* serializar_paquete(t_paquete* paquete, int *bytes)
 {
 
 }

--- a/utils.c
+++ b/utils.c
@@ -8,6 +8,10 @@
 #include "utils.h"
 
 //TODO
+/*
+ * Recibe un paquete a serializar, y un puntero a un int en el que dejar
+ * el tamaño del stream de bytes serializados que devuelve
+ */
 void* serializar_paquete(t_paquete* paquete, int *bytes)
 {
 


### PR DESCRIPTION
Con la firma anterior, la función recibía el tamaño del buffer a enviar - dato que ya se encuentra en `paquete->buffer->size`.

Además, quedaba como responsabilidad del usuario de la función asumir cuál era el tamaño del stream serializado resultante.

Si, en cambio, recibimos un puntero a un int que podemos escribir, la función calcula el tamaño del stream resultante, y se lo "devuelve" al usuario de la función. Evitamos un dato redundante, y evitamos que el usuario asuma cosas sobre el funcionamiento interno de la función.